### PR TITLE
Adding Version Compatibility In Info File

### DIFF
--- a/views_nested_accordion.info.yml
+++ b/views_nested_accordion.info.yml
@@ -2,6 +2,7 @@ name: Views Nested Accordion
 type: module
 description: Add new style Views Nested Accordion to the Views Style list, which helps in creating Nested Accordion.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Views
 dependencies:
   - drupal:views


### PR DESCRIPTION
The info file of this module was not compatible with Drupal 9, And the end goal of this issue is to fix the same.